### PR TITLE
Fake simprints identification response

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.dimagi.test.external"
+<manifest package="com.dimagi.test.external"
+          xmlns:android="http://schemas.android.com/apk/res/android"
           android:versionName="1.0">
 
     <uses-permission android:name="org.commcare.dalvik.provider.cases.read"/>
@@ -46,7 +46,12 @@
         </activity>
 
         <activity android:name="IntentReceiverTest"/>
+
+        <activity android:name="SimprintsIdentifyTest">
+            <intent-filter>
+                <action android:name="org.commcare.dalvik.fake.simprints.IDENTIFY"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
     </application>
-
-
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,16 @@ buildscript {
 repositories {
     mavenCentral()
     jcenter()
+    // for local aar inclusion
+    flatDir {
+        dirs 'libs'
+    }
 }
 apply plugin: 'com.android.application'
 
 dependencies {
     compile 'com.android.support:support-v4:23.3.0'
+    compile(name: 'simprints-lib', ext: 'aar')
 }
 
 android {

--- a/src/com/dimagi/test/external/SimprintsIdentifyTest.java
+++ b/src/com/dimagi/test/external/SimprintsIdentifyTest.java
@@ -1,0 +1,73 @@
+package com.dimagi.test.external;
+
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.CursorLoader;
+import android.support.v4.content.Loader;
+
+import com.simprints.libsimprints.Identification;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+/**
+ * Respond to a 'fake' Simprints fingerprint identification request by loading
+ * the case list, picking the top N cases, adding incrementing confidence score
+ * and returning that list to CommCare
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class SimprintsIdentifyTest extends FragmentActivity implements
+        LoaderManager.LoaderCallbacks<Cursor> {
+    private static final int CASE_LOADER = 0;
+    private static final int RESULT_COUNT = 3;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        getSupportLoaderManager().initLoader(CASE_LOADER, null, this);
+    }
+
+    @Override
+    public Loader<Cursor> onCreateLoader(int loaderID, Bundle args) {
+        switch (loaderID) {
+            case CASE_LOADER:
+                Uri tableUri = Uri.parse("content://org.commcare.dalvik.case/casedb/case");
+                return new CursorLoader(this, tableUri, null, null, null, null);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public void onLoadFinished(Loader<Cursor> loader, Cursor caseData) {
+        Intent indentificationIntent = new Intent();
+        ArrayList<Identification> ids = new ArrayList<>();
+
+        caseData.moveToFirst();
+        int index = caseData.getColumnIndexOrThrow("case_id");
+
+        float confidence = 0.0f;
+        while (!caseData.isAfterLast() && (ids.size() < RESULT_COUNT)) {
+            String caseId = caseData.getString(index);
+            ids.add(new Identification(caseId, confidence));
+            confidence += 0.2f;
+            caseData.moveToNext();
+        }
+        caseData.close();
+        Collections.sort(ids);
+        indentificationIntent.putParcelableArrayListExtra("identification", ids);
+        setResult(RESULT_OK, indentificationIntent);
+        finish();
+    }
+
+    @Override
+    public void onLoaderReset(Loader<Cursor> loader) {
+
+    }
+}


### PR DESCRIPTION
Register action `org.commcare.dalvik.fake.simprints.IDENTIFY` that will get the current case list from CommCare and take the first 3 cases, attach confidence scores, and pass back the list in the Simprints format that CommCare expects.

![screen](https://cloud.githubusercontent.com/assets/94817/14925414/4ead350a-0e15-11e6-96de-b71e4c9c2273.png)
![screen](https://cloud.githubusercontent.com/assets/94817/14925419/57cba054-0e15-11e6-9db4-9880ae528c03.png)
