### PR TITLE
Improve app discoverability

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -9,6 +9,7 @@
 
     <queries>
         <provider android:authorities="org.commcare.dalvik.case" />
+        <provider android:authorities="org.commcare.dalvik.fixture" />
     </queries>
 
     <application

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-permission android:name="org.commcare.dalvik.debug.provider.cases.read"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
+    <queries>
+        <provider android:authorities="org.commcare.dalvik.case" />
+    </queries>
+
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">


### PR DESCRIPTION
This PR adds CommCare's Content Providers authorities to the app. Android 11 brought stricter rules around the amount of apps installed in the device a given app can access, this is now filtered and the principle being providing only the necessary for the app to function. This means that any additional requirements need to be declared, and with CommCare now targeting Android 12 the content providers became inaccessible to the app.